### PR TITLE
fixed confusion matrix definitions to accord with scikit learn

### DIFF
--- a/JACS-ML-Tutorial/src/python/ClassifierStats.py
+++ b/JACS-ML-Tutorial/src/python/ClassifierStats.py
@@ -17,17 +17,17 @@ along with JACS ML Tutorial.  If not, see <http://www.gnu.org/licenses/>.
 File name:    ClassifierStats.py
 Created:      October 30th, 2014
 Author:       Rob Lyon
- 
+
 Contact:    rob@scienceguyrob.com or robert.lyon@postgrad.manchester.ac.uk
-Web:        <http://www.scienceguyrob.com> or <http://www.cs.manchester.ac.uk> 
+Web:        <http://www.scienceguyrob.com> or <http://www.cs.manchester.ac.uk>
             or <http://www.jb.man.ac.uk>
 
 Computes and stores the performance statistics of a classifier
 given a confusion matrix containing its true positive, false positive,
 true negative and false negative rates.
 
-Designed to run on python 2.4 or later. 
- 
+Designed to run on python 2.4 or later.
+
 """
 
 from numpy import sqrt
@@ -39,57 +39,57 @@ from numpy import sqrt
 # ******************************
 
 class ClassifierStats:
-    """                
-    Computes the performance statistics of a BINARY classifier only.
-    
     """
-    
+    Computes the performance statistics of a BINARY classifier only.
+
+    """
+
     # ****************************************************************************************************
     #
     # Constructor.
     #
     # ****************************************************************************************************
-    
+
     def __init__(self,confusionMatrix):
         """
         Default constructor.
-        
+
         Parameters:
-        
+
         confusionMatrix     -    a matrix containing the performance of a given BINARY classifier on
                                  a training set. For example given the matrix,
-                                 
+
                                  [[15528   731]
                                  [  249  1390]]
-                                 
+
                                  Where,
-                                 
+
                                  TrueNegatives  = confusionMatrix[0][0] # Negatives correctly receiving negative label.
-                                 FalseNegatives = confusionMatrix[0][1] # Positives incorrectly receiving negative label.
-                                 FalsePositives = confusionMatrix[1][0] # Negatives incorrectly receiving positive label.
+                                 FalseNegatives = confusionMatrix[1][0] # Positives incorrectly receiving negative label.
+                                 FalsePositives = confusionMatrix[0][1] # Negatives incorrectly receiving positive label.
                                  TruePositives  = confusionMatrix[1][1] # Positives correctly receiving positive label.
-                                 
+
                                  Will not evaluate the performance of multi-class classifiers.
         """
-        
+
         # The accuracy of the classifier.
         self.accuracy = 0.0
-        
+
         # The precision of the classifier. Precision is the fraction of retrieved instances that are relevant.
         self.precision = 0
-        
+
         # The recall of the classifier. Recall is the fraction of relevant instances that are retrieved.
         self.recall = 0.0
-        
+
         # The precision of the map. Specificity relates to the ability of the map to identify negative results.
         self.specificity = 0.0
-        
+
         # The negative predictive value (NPV) is a summary statistic
         # defined as the proportion of input patterns identified as negative,
         # that are correctly identified as such. A high NPV means that when the
         # classifier yields a negative result, it is most likely correct in its assessment.
         self.negativePredictiveValue = 0.0
-        
+
         # The Matthews correlation coefficient is used in machine learning
         # as a measure of the quality of binary (two-class) classifications.
         # It takes into account true and false positives and negatives and
@@ -101,89 +101,89 @@ class ClassifierStats:
         # and -1 indicates total disagreement between prediction and observation.
         # The statistic is also known as the phi coefficient.
         self.matthewsCorrelation = 0.0
-        
+
         # The F1 score (also F-score or F-measure) is a measure of a classifier's accuracy.
         # It considers both the precision p and the recall r of the classifier to compute
         # the score: p is the number of correct results divided by the number of all
         # returned results and r is the number of correct results divided by the
         # number of results that should have been returned.
         self.fScore = 0.0
-        
+
         # The g-mean is a measure of useful for data sets with skewed class distributions.
         # In other words when most examples belong to one class (say the negative), then this
-        # metric helps asses performance irrespective of the imbalance. It evaluates the 
+        # metric helps asses performance irrespective of the imbalance. It evaluates the
         # inductive bias in terms of the ratio between positive and negative accuracy.
         self.gmean = 0.0
-        
+
         # The kappa statistic. Cohen's kappa coefficient is a statistical measure of inter-rater
         # agreement or inter-annotator agreement for qualitative (categorical) items. It is
         # generally thought to be a more robust measure than simple percent agreement
         # calculation since k takes into account the agreement occurring by chance.
         self.kappa = 0.0
-        
+
         # The true positives.
         self.TP = 0.0
-        
+
         # The true negatives.
         self.TN = 0.0
-        
+
         # The false positives.
         self.FP = 0.0
-        
+
         # The false negatives.
         self.FN = 0.0
-        
+
         # The area under the roc curve.
         self.auroc = float('NaN')
-        
+
         # The area under the precision-recall curve.
         self.auprc = float('NaN')
-        
+
         self.load(confusionMatrix)
         self.calculate()
-                          
-                
+
+
     # ****************************************************************************************************
-     
+
     def load(self,confusionMatrix):
         """
         Loads data from the confusion matrix into the correct variables.
-        
+
         Parameters:
-        
+
         confusionMatrix     -    a matrix containing the performance of a given BINARY classifier on
                                  a training set. For example given the matrix,
-                                 
+
                                  [[15528   731]
                                  [  249  1390]]
-                                 
+
                                  Where,
-                                 
+
                                  TrueNegatives  = confusionMatrix[0][0] # Negatives correctly receiving negative label.
-                                 FalseNegatives = confusionMatrix[0][1] # Positives incorrectly receiving negative label.
-                                 FalsePositives = confusionMatrix[1][0] # Negatives incorrectly receiving positive label.
+                                 FalseNegatives = confusionMatrix[1][0] # Positives incorrectly receiving negative label.
+                                 FalsePositives = confusionMatrix[0][1] # Negatives incorrectly receiving positive label.
                                  TruePositives  = confusionMatrix[1][1] # Positives correctly receiving positive label.
-                                 
+
                                  Will not evaluate the performance of multi-class classifiers.
-                                 
+
         Returns:    N/A.
         """
-        
+
         self.TN = float(confusionMatrix[0][0]) # Negatives correctly receiving negative label.
-        self.FN = float(confusionMatrix[0][1]) # Positives incorrectly receiving negative label.
-        self.FP = float(confusionMatrix[1][0]) # Negatives incorrectly receiving positive label.
+        self.FN = float(confusionMatrix[1][0]) # Positives incorrectly receiving negative label.
+        self.FP = float(confusionMatrix[0][1]) # Negatives incorrectly receiving positive label.
         self.TP = float(confusionMatrix[1][1]) # Positives correctly receiving positive label.
-            
+
     # ****************************************************************************************************
-        
+
     def calculate(self):
         """
         Computes the values of the statistics describing classifier performance.
-        
+
         Parameters: None.
-        
+
         Returns:    N/A.
-        
+
         """
         self.accuracy = (self.TP + self.TN) / (self.TP + self.FP + self.FN + self.TN)
 
@@ -199,7 +199,7 @@ class ClassifierStats:
         sqrt((self.TP+self.FP) * (self.TP+self.FN) * (self.TN+self.FP) * (self.TN+self.FN))
 
         self.fScore = 2 * ((self.precision * self.recall) / (self.precision + self.recall))
-        
+
         # Kappa = (totalAccuracy - randomAccuracy) / (1 - randomAccuracy)
         #
         # where,
@@ -212,22 +212,22 @@ class ClassifierStats:
         total     = self.TP + self.TN + self.FP + self.FN
         totalAcc  = (self.TP + self.TN) / (self.TP + self.TN + self.FP + self.FN)
         randomAcc =  (((self.TN + self.FP) * (self.TN + self.FN)) + ((self.FN + self.TP) * (self.FP + self.TP))) / (total*total)
-        
+
         self.kappa = (totalAcc - randomAcc) / (1 - randomAcc)
 
         self.gmean = sqrt( ( self.TP /( self.TP + self.FN ) ) * ( self.TN / ( self.TN + self.FP ) ) )
-    
+
     # ****************************************************************************************************
-    
+
     def show(self):
         """
         Prints classifier performance stats to standard output.
-        
+
         Parameters: None.
-        
+
         Returns:    N/A.
         """
-        
+
         output ='{:<14}'.format("TP:")         +"\t" + str(int(self.TP))                       + "\n" +\
                 '{:<14}'.format("TN:")         +"\t" + str(int(self.TN))                       + "\n" +\
                 '{:<14}'.format("FP:")         +"\t" + str(int(self.FP))                       + "\n" +\
@@ -243,49 +243,49 @@ class ClassifierStats:
                 '{:<14}'.format("G-Mean:" )    +"\t" + str(self.gmean)                         +"\n" +\
                 '{:<14}'.format("AUROC:" )     +"\t" + str(self.auroc)                         +"\n" +\
                 '{:<14}'.format("AUPRC:" )     +"\t" + str(self.auprc)                         +"\n"
-        
+
         print output
 
     # ****************************************************************************************************
-    
+
     def toCSV(self):
         """
         Returns the performance statistics of the classifier to CSV format.
-        
+
         Parameters: None.
-        
+
         Returns:    The statistics in CSV format as follows:
-        
+
                     TP,TN,FP,FN,ACCURACY,PRECISION,RECALL,SPECIFICITY,NPV,MCC,FSCORE,GMEAN,KAPPA,AUROC,AUPRC
         """
         return str(int(self.TP)) + "," + str(int(self.TN)) + "," + str(int(self.FP)) + "," + str(int(self.FN)) + "," + str(self.accuracy) + "," +\
             str(self.precision) + "," + str(self.recall) +","+ str(self.specificity) + "," + str(self.negativePredictiveValue) +\
             "," + str(self.matthewsCorrelation) + "," + str(self.fScore) + "," + str(self.gmean) + "," + str(self.kappa)+ "," + str(self.auroc) + ","+\
             +str(self.auprc),
-    
+
     # ****************************************************************************************************
-        
+
     # ******************************
-    #           Getters 
+    #           Getters
     # ******************************
 
-  
+
     def getAccuracy(self):
         """
         Accuracy of the classifier where accuracy = (TP + TN) / (TP + FP + FN + TN).
-        
+
         Parameters: None.
-        
+
         Returns:    accuracy as a float.
         """
         return float(self.accuracy)
-  
+
     def getPrecision(self):
         """
         Precision of the classifier where precision = (TP) / (TP + FP).
-        
+
         Parameters: None.
-        
+
         Returns:    precision as a float.
         """
         return float(self.precision)
@@ -293,9 +293,9 @@ class ClassifierStats:
     def getRecall(self):
         """
         Recall of the classifier where recall = (TP) / (TP + FN).
-        
+
         Parameters: None.
-        
+
         Returns:    recall as a float.
         """
         return float(self.recall)
@@ -304,9 +304,9 @@ class ClassifierStats:
     def getSpecificity(self):
         """
         Specificity of the classifier where specificity = (TN) / (FP+TN).
-        
+
         Parameters: None.
-        
+
         Returns:    specificity as a float.
         """
         return float(self.specificity)
@@ -315,11 +315,11 @@ class ClassifierStats:
     def getMatthewsCorrelation(self):
         """
         Matthew's Correlation Coefficient of the classifier where,
-        
+
         matthewsCorrelation = ((TP * TN) - (FP * FN)) / sqrt((TP+FP) * (TP+FN) * (TN+FP) * (TN+FN)).
-        
+
         Parameters: None.
-        
+
         Returns:    mcc as a float.
         """
         return float(self.matthewsCorrelation)
@@ -327,9 +327,9 @@ class ClassifierStats:
     def getfScore(self):
         """
         F-Score of the classifier where fScore = 2 * ((precision * recall) / (precision + recall)).
-        
+
         Parameters: None.
-        
+
         Returns:    F-score as a float.
         """
         return float(self.fScore)
@@ -337,29 +337,29 @@ class ClassifierStats:
     def getNegativePredictiveValue(self):
         """
         Negative predictive value of the classifier where negativePredictiveValue = (TN) / (FN + TN).
-        
+
         Parameters: None.
-        
+
         Returns:    npv as a float.
         """
         return float(self.negativePredictiveValue)
-  
+
     def getKappa(self):
         """
         Cohen's Kappa of the classifier where,
-        
+
         kappa = (totalAccuracy - randomAccuracy) / (1 - randomAccuracy)
-        
+
         where,
-        
+
         totalAccuracy = (TP + TN) / (TP + TN + FP + FN)
-        
+
         and
-        
+
         randomAccuracy = (TN + FP) * (TN + FN) + (FN + TP) * (FP + TP) / (Total*Total).
-        
+
         Parameters: None.
-        
+
         Returns:    kappa as a float.
         """
         return float(self.kappa)
@@ -367,63 +367,63 @@ class ClassifierStats:
     def getGMean(self):
         """
         G-mean of the classifier where gmean = sqrt( ( TP /( TP + FN ) ) * ( TN / ( TN + FP ) ) ).
-        
+
         Parameters: None.
-        
+
         Returns:    gmean as a float.
         """
         return float(self.gmean)
-    
+
     def getAUROC(self):
         """
         Area under the roc curve of the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    auroc as a float.
         """
         return float(self.auroc)
-    
+
     def setAUROC(self,auroc):
         """
         Sets the Area under the roc curve of the classifier.
-        
+
         Parameters:
-        
+
         auroc    -    the area under the roc curve calculated externally.
-        
+
         Returns:    None.
         """
         self.auroc = auroc
-    
+
     def getAUPRC(self):
         """
         Area under the precision-recall curve of the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    auroc as a float.
         """
         return float(self.auprc)
-    
+
     def setAUPRC(self,auprc):
         """
         Sets the Area under the precision-recall curve of the classifier.
-        
+
         Parameters:
-        
+
         auprc    -    the area under the precision-recall curve calculated externally.
-        
+
         Returns:    None.
         """
         self.auprc = auprc
- 
+
     def getTP(self):
         """
         True positives (TP) returned by the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    true positives as an integer.
         """
         return int(self.TP)
@@ -431,31 +431,31 @@ class ClassifierStats:
     def getTN(self):
         """
         True negatives (TN) returned by the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    true negatives as an integer.
         """
         return int(self.TN)
-  
+
     def getFP(self):
         """
         False positives (FP) returned by the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    false positives as an integer.
         """
         return int(self.FP)
- 
+
     def getFN(self):
         """
         False negatives (FN) returned by the classifier.
-        
+
         Parameters: None.
-        
+
         Returns:    false negatives as an integer.
         """
         return int(self.FN)
-    
+
     # ****************************************************************************************************

--- a/JACS-ML-Tutorial/src/python/SciKitLearnTest.py
+++ b/JACS-ML-Tutorial/src/python/SciKitLearnTest.py
@@ -17,15 +17,15 @@ along with JACS ML Tutorial.  If not, see <http://www.gnu.org/licenses/>.
 File name:    SciKitLearnTest.py
 Created:      October 30th, 2014
 Author:       Rob Lyon
- 
+
 Contact:    rob@scienceguyrob.com or robert.lyon@postgrad.manchester.ac.uk
-Web:        <http://www.scienceguyrob.com> or <http://www.cs.manchester.ac.uk> 
+Web:        <http://www.scienceguyrob.com> or <http://www.cs.manchester.ac.uk>
             or <http://www.jb.man.ac.uk>
 
 An example showing some of the capabilities of SciKit-Learn.
 
-Designed to run on python 2.4 or later. 
- 
+Designed to run on python 2.4 or later.
+
 """
 
 # Classifier imports:
@@ -63,12 +63,12 @@ import ClassifierStats
 #*****************************
 
 class SciKitLearnTest:
-    """                
-    A simple example showing how to load ARFF data into SciKit-Learn, 
-    and use it for classification.
-    
     """
-    
+    A simple example showing how to load ARFF data into SciKit-Learn,
+    and use it for classification.
+
+    """
+
     #*****************************
     #
     # MAIN METHOD AND ENTRY POINT.
@@ -78,9 +78,9 @@ class SciKitLearnTest:
     def main(self,argv=None):
         """
         Main entry point for the Application.
-    
+
         """
-        
+
         print "\n****************************"
         print "|                          |"
         print "|   SciKit-Learn Example   |"
@@ -89,7 +89,7 @@ class SciKitLearnTest:
         print "| Version 1.0              |"
         print "| robert.lyon@cs.man.ac.uk |"
         print "***************************\n"
-        
+
         # Please use only binary (two-class) data sets for this test script.
         # If using multi-class data sets you'll need to evaluate them slightly
         # differently, and luckily SciKit-Learn provides these tools for you.
@@ -100,23 +100,23 @@ class SciKitLearnTest:
         # variable 1, variable 2, ... , variable n, class label
         #
         # where the class label must be an integer value, and the variables doubles, floats or integers.
-        
-        # Just alter the path to some data sets on your local machine.    
+
+        # Just alter the path to some data sets on your local machine.
         dataPath = "/Users/rob/Dropbox/Documents/SharedWorkspace/JACS_ML_Examples/data/magic.arff"
-        
+
         # Create ARFF file object.
         arff = ARFF.ARFF()
-        
+
         # Here I'm loading the test and training data from a single file.
         # data_X contains the data, and data_Y the correct class labels.
         data_X ,data_Y  = arff.read(dataPath)
-        
+
         # In this example we have training and test data in a single file. so we need to
         # sample it in order to generate training and test data sets. This can be done as follows:
         #
         # train_X, test_X, train_Y, test_Y = cross_validation.train_test_split(allData_X, allData_Y, test_size=0.4, random_state=0)
-        # 
-        # This creates random test and train splits such that 40% of the data is used for testing. Note that 
+        #
+        # This creates random test and train splits such that 40% of the data is used for testing. Note that
         # random_state is a random number used to seed a random sampler.
         #
         # It's equally valid to have test and training data sets sampled elsewhere. In which case you load
@@ -133,7 +133,7 @@ class SciKitLearnTest:
         # in a given sample. If you're not sure which type of sampling to use, Stratified sampling
         # is usually the better choice, since you know your training & test samples will have the same data
         # distribution.
-        # 
+        #
         # This is important since if you train on an unrepresentative distribution,
         # you may get strange performance in practice. This is because your classifier may 'overfit'
         # to the training distribution. For example: imagine you train a classifier upon data which is
@@ -145,10 +145,10 @@ class SciKitLearnTest:
         # The data are also shuffled so that we can be sure data ordering isn't a factor. Note the call to
         # StratifiedKFold simply chooses indices for the sample, and doesn't generate new data objects.
         skf = StratifiedKFold(data_Y, 2, shuffle=True,random_state=0)
-            
+
         # The names of the classifiers being used...
         names = ["Linear SVM", "Decision Tree", "Random Forest", "Naive Bayes"]
-        
+
         # Initializes and stores the actual classifiers to use.
         classifiers = [
                        SVC(kernel="linear", C=0.025,probability=True),
@@ -156,26 +156,26 @@ class SciKitLearnTest:
                        RandomForestClassifier(max_depth=5, n_estimators=10, max_features=1),
                        GaussianNB()
                        ]
-        
+
         # Stores the results gathered below for comparison.
         aggregateResultsDict = {}
-        
+
         # iterate over classifiers
         for name, classifier in zip(names, classifiers):
-            
+
             # Some examples of using the classifiers provided below:
-            
+
             print "Testing Classifier: " , name
-            
+
             # Keeps count of the folds.
             fold = 0
             # Stores the results for each fold.
             results = []
-            
+
             for train_index, test_index in skf:
-                
+
                 fold+=1
-                
+
                 print "\nRunning " , name , " on fold ", str(fold)
                 train_X, test_X = data_X[train_index], data_X[test_index]
                 train_Y, test_Y = data_Y[train_index], data_Y[test_index]
@@ -185,31 +185,31 @@ class SciKitLearnTest:
                 # Now obtain the classifiers 'score'
                 accuracy = classifier.score(test_X, test_Y)
                 print "\n",name," : ", accuracy # newline char at start simply for formatting.
-                
+
                 # But accuracy alone is insufficient to determine how well
                 # a classifier performs on a test data set. So we really need
                 # more metrics. An alternative to the above (and how we do things in ML) is to make
                 # some predictions. Calling classifier.predict will return a set
                 # of predicted labels which we can evaluate against test_Y (true labels).
                 predictions = classifier.predict(test_X)
-                
+
                 # From the predictions we can compute a confusion matrix, which describes how
                 # predicted labels were assigned. The matrix has the form:
                 #
-                #      Actual Class
+                #      Pred
                 #        -     +
-                # P    -----------
-                # r  - | TN | FN |    TN = Negatives correctly receiving negative label.
-                # e    |---------|    FN = Positives incorrectly receiving negative label.
-                # d  + | FP | TP |    FP = Negatives incorrectly receiving positive label.
-                # .    -----------    TP = Positives correctly receiving positive label.
-                #
+                # A    -----------
+                # c  - | TN | FP |    TN = Negatives correctly receiving negative label.
+                # t    |---------|    FN = Positives incorrectly receiving negative label.
+                # u  + | FN | TP |    FP = Negatives incorrectly receiving positive label.
+                # a    -----------    TP = Positives correctly receiving positive label.
+                # l
                 # ^
                 # |
                 # Predicted.
                 confusionMatrix = confusion_matrix(test_Y,predictions)
                 #print "Confusion matrix for ",name,":\n",confusionMatrix
-                
+
                 # Show confusion matrix in a separate window - uncomment if you'd
                 # like to see it.
                 #plt.matshow(confusionMatrix)
@@ -218,22 +218,22 @@ class SciKitLearnTest:
                 #plt.ylabel('True label')
                 #plt.xlabel('Predicted label')
                 #plt.show()
-                
+
                 # For this part of the evaluation, we assume the two classes used
                 # in the test and training data sets represent positive (1) and negative (0).
-                
+
                 TrueNegatives  = confusionMatrix[0][0] # Negatives correctly receiving negative label.
-                FalseNegatives = confusionMatrix[0][1] # Positives incorrectly receiving negative label.
-                FalsePositives = confusionMatrix[1][0] # Negatives incorrectly receiving positive label.
+                FalseNegatives = confusionMatrix[1][0] # Positives incorrectly receiving negative label.
+                FalsePositives = confusionMatrix[0][1] # Negatives incorrectly receiving positive label.
                 TruePositives  = confusionMatrix[1][1] # Positives correctly receiving positive label.
-                
-                # From this we obtain these key values from which we can 
+
+                # From this we obtain these key values from which we can
                 # calculate classifier performance statistics.
                 print "True Negatives  : " , TrueNegatives
                 print "False Negatives : " , FalseNegatives
                 print "False Positives : " , FalsePositives
                 print "True Positives  : " , TruePositives, "\n\n"
-                
+
                 # From the values in the confusion matrix, we can calculate many performance metrics.
                 # I've already written a class that allow you to automatically calculate
                 # a whole bunch of these statistics. Here we construct this class object, then
@@ -242,33 +242,33 @@ class SciKitLearnTest:
                 classifierStats = ClassifierStats.ClassifierStats(confusionMatrix)
                 print "More detailed statistics on ", name , " performance for fold " , fold , "."
                 classifierStats.show()
-                
+
                 # But what if we want to produce a ROC curve? Well first we have to make sure
                 # we are using a classifier that produces continuous output values, i.e probabilities.
                 # Then the ROC curve can be computed. The ROC alters the threshold at which each instance
                 # is classified. For example if the Threshold is 0.5, then we say everything receiving
                 # a value below this is negative, and above is positive. Since we know the true class labels
-                # we can draw a curve showing how many errors are made when altering this threshold, given predicted 
+                # we can draw a curve showing how many errors are made when altering this threshold, given predicted
                 # probabilities and the the true class labels. By trying a variety of thresholds at small step
                 # size, we produce a curve. See wikipedia for a detailed discussion of ROC curves. Even better,
                 # check out this paper which describes them very well:
                 # "An introduction to ROC analysis", Tom Fawcett, 2006 (https://ccrma.stanford.edu/workshops/mir2009/references/ROCintro.pdf)
-                
+
                 # Gets the probabilities. Note that we have to tell some classifiers explicitly
                 # to output probabilities, e.g. SVC(kernel="linear", C=0.025,probability=True).
                 probs = classifier.predict_proba(test_X)
-                
+
                 # Obtains the data for the curve.
                 fpr, tpr, thresholds = roc_curve(test_Y, probs[:, 1])
-                
-                # Calculates the single area under the curve (AUC) metric. This is simply a 
+
+                # Calculates the single area under the curve (AUC) metric. This is simply a
                 # single metric which summarizes the ROC.
                 roc_auc = auc(fpr, tpr)
-                print "Area under the ROC curve : %f" % roc_auc 
-                
+                print "Area under the ROC curve : %f" % roc_auc
+
                 # Store this value in the stats object for later use.
                 classifierStats.setAUROC(roc_auc)
-                
+
                 plt.clf()
                 plt.plot(fpr, tpr, label='ROC curve (area = %0.2f)' % roc_auc)
                 plt.plot([0, 1], [0, 1], 'k--')
@@ -278,22 +278,22 @@ class SciKitLearnTest:
                 plt.ylabel('True Positive Rate')
                 plt.title('Receiver operating characteristic for ' + name + " on fold " + str(fold))
                 plt.legend(loc="lower right")
-                plt.show()  
-                
+                plt.show()
+
                 # Now compute Precision-Recall and plot curve. This is very useful to get
                 # a feel for how precise your classifier is. A very precise classifier with low positive
                 # class recall is not helpful, likewise high recall with low precision is equally bad
                 # (everything would be returned as a positive). So there is a trade-off to be had, and this
                 # visualizes the trade-off.
                 precision, recall, pr_thresholds =  precision_recall_curve(test_Y, probs[:, 1])
-                
+
                 # Calculates the single area under the precision-recall curve (AUPRC) metric.
                 auprc = auc(recall,precision)
-                print "Area under the PR curve : %f" % auprc 
-                
+                print "Area under the PR curve : %f" % auprc
+
                 # Store this value in the stats object for later use.
                 classifierStats.setAUPRC(auprc)
-                
+
                 # Plot Precision-Recall curve
                 plt.clf()
                 plt.plot(recall, precision, label='Precision-Recall curve (area = %0.2f)' % auprc)
@@ -304,27 +304,27 @@ class SciKitLearnTest:
                 plt.title('Precision-Recall curve for ' + name + " on fold " + str(fold))
                 plt.legend(loc="lower left")
                 plt.show()
-                
+
                 # Now we have results per fold, but these need to be aggregated to get overall results
                 # For now we store these in the results object.
                 results.append(classifierStats)
-                
+
                 # Just some formatting to make it easier to visually separate fold results at the terminal.
-                print "\n########################################\n"     
-                
-            
+                print "\n########################################\n"
+
+
             # Now outside of the loop over the folds, we can aggregate individual classifier performance.
             # This isn't the most efficient way to compute this (probably), but it's the easiest to follow
             # and improve upon.
-            
-            
+
+
             total_TP    = 0.0
             total_TN    = 0.0
             total_FP    = 0.0
             total_FN    = 0.0
             total_auroc = 0.0
             total_auprc = 0.0
-            
+
             for cs in results:
                 total_TP+= cs.getTP()
                 total_TN+= cs.getTN()
@@ -332,7 +332,7 @@ class SciKitLearnTest:
                 total_FN+= cs.getFN()
                 total_auroc+= cs.getAUROC()
                 total_auprc+= cs.getAUPRC()
-            
+
             tests = len(results)
             avg_TP    = total_TP    / tests
             avg_TN    = total_TN    / tests
@@ -340,70 +340,70 @@ class SciKitLearnTest:
             avg_FN    = total_FN    / tests
             avg_auroc = total_auroc / tests
             avg_auprc = total_auprc / tests
-            
-            avgConfusionMatrix = [[avg_TN,avg_FN],[avg_FP,avg_TP]]    
+
+            avgConfusionMatrix = [[avg_TN,avg_FN],[avg_FP,avg_TP]]
             aggregateStats = ClassifierStats.ClassifierStats(avgConfusionMatrix)
             aggregateStats.setAUROC(avg_auroc)
             aggregateStats.setAUPRC(avg_auprc)
-            
+
             print "\nAggregate results for " , name , "\n"
             aggregateStats.show()
-            
+
             aggregateResultsDict[name] = aggregateStats; # Add new entry
-            
+
             # So now you have the data, what to do with it? Normally we would
-            # Write it to a file for further analysis, for example significance 
+            # Write it to a file for further analysis, for example significance
             # tests, ANOVA analysis etc.
-            
+
             # Just some formatting to make it easier to visually separate results at the terminal.
-            print "\n********************************************************************************\n"     
-        
+            print "\n********************************************************************************\n"
+
         # Now we can use the aggregateResultsDict object to compare results
         # and determine which classifier is best for our data. For example:
-        
+
         print "\nExample comparisons:\n"
         # NOTE: names[0]="Linear SVM" and names[1]="Decision Tree"
         if(aggregateResultsDict[names[0]].getGMean() < aggregateResultsDict[names[1]].getGMean()):
-            
+
             diff = aggregateResultsDict[names[0]].getGMean()-aggregateResultsDict[names[1]].getGMean()
             print str(names[0]) , " achieved lower G-Mean than ", str(names[1]), ", diff: ", diff
-            
+
         elif(aggregateResultsDict[names[0]].getGMean() > aggregateResultsDict[names[1]].getGMean()):
-            
+
             diff = aggregateResultsDict[names[0]].getGMean()-aggregateResultsDict[names[1]].getGMean()
             print str(names[0]) , " achieved higher G-Mean than ", str(names[1]), ", diff: ", diff
-            
+
         else:
             print str(names[0]) , " achieved the same G-Mean as ", str(names[1])
-        
+
         # Or loop over the results....
-        
+
         # Set initial best to compare to
         best = aggregateResultsDict[names[0]]
         name = names[0]
         for key in aggregateResultsDict:
-            
+
             if(aggregateResultsDict[key].getGMean() > best.getGMean()):
                 best = aggregateResultsDict[key]
                 name = key
-        
+
         print "Classifier that achieved the best G-Mean overall was" , name, " where G-Mean = ", str(best.getGMean())
-        
+
         # Or for another metric....
         # Set initial best to compare to
         best = aggregateResultsDict[names[0]]
         name = names[0]
         for key in aggregateResultsDict:
-            
+
             if(aggregateResultsDict[key].getFP() > best.getFP()):
                 best = aggregateResultsDict[key]
                 name = key
-        
+
         print "Classifier that produced the most false positives was" , name, " where FP = ", str(best.getFP())
-            
+
         print "\nDone."
-    
+
     #***************************************************************************************************
-      
+
 if __name__ == '__main__':
     SciKitLearnTest().main()


### PR DESCRIPTION
The definitions used in these files for the confusion matrix are _different_ to those used by scikit-learn. This tutorial quotes the confusion matrix C as being defined as 
C[i,j] = number of class predicted to be i actually in class j.
However, scikit-learn uses the definition 
C[i,j] = number of class actually in i classified as j 
as can be seen [here](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.confusion_matrix.html) and [here](http://scikit-learn.org/stable/modules/model_evaluation.html#confusion-matrix). Therefore, if the ClassifierStats class is actually used with the confusion matrix generated by scikit-learn, all metrics like precision and recall are the wrong way round.
This fork fixes this, by simply changing the definition to be consistent with the scikit-learn definition throughout.